### PR TITLE
Added VNet support for Linux VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,8 @@ You can execute the plugin from both Windows and Linux dev-boxes (clients).
   * export PACKER_LOG_PATH=$HOME/packer.log
 
 * Known Issues
-  * It was discovered that some Linux distributions behave strangely as a target. in particular, if a user 
-    1. creates a VM from a **OpenLogin image** using **certificate authentication only**;
+  * It was discovered that some Linux distributions behave strangely as a target. In particular, if a user 
+    1. creates a VM from an **OpenLogic image** using **certificate authentication only**;
     2. captures the VM to an user image;
     3. creates a VM from the captured image using **password and certificate authentication** - password authentication won't work.
 

--- a/packer/builder/azure/driver_powershell/builder.go
+++ b/packer/builder/azure/driver_powershell/builder.go
@@ -286,6 +286,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				InstanceSize:   b.config.InstanceSize,
 				Username:       b.config.username,
 				ContainerUrl:   containerUrl,
+				Subnet:         b.config.Subnet,
+				VNet:           b.config.VNet,
 			},
 			&target.StepGetEndpoint{
 				OsType:         b.config.OsType,
@@ -348,6 +350,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				Username:       b.config.username,
 				Password:       password,
 				ContainerUrl:   containerUrl,
+				Subnet:         b.config.Subnet,
+				VNet:           b.config.VNet,
 			},
 
 			&win.StepInstallCertificate{

--- a/packer/builder/azure/driver_powershell/builder.go
+++ b/packer/builder/azure/driver_powershell/builder.go
@@ -10,6 +10,10 @@ import (
 	"fmt"
 	"log"
 
+	"os"
+	"regexp"
+	"time"
+
 	ps "github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_powershell/driver"
 	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_powershell/target"
 	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_powershell/target/lin"
@@ -18,9 +22,6 @@ import (
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/common"
 	"github.com/mitchellh/packer/packer"
-	"os"
-	"regexp"
-	"time"
 )
 
 // Builder implements packer.Builder and builds the actual Azure
@@ -40,6 +41,8 @@ type azure_config struct {
 	Location                string `mapstructure:"location"`
 	InstanceSize            string `mapstructure:"instance_size"`
 	UserImageLabel          string `mapstructure:"user_image_label"`
+	VNet                    string `mapstructure:"vnet"`
+	Subnet                  string `mapstructure:"subnet"`
 	common.PackerConfig     `mapstructure:",squash"`
 	tpl                     *packer.ConfigTemplate
 
@@ -80,6 +83,8 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		"location":                  &b.config.Location,
 		"instance_size":             &b.config.InstanceSize,
 		"user_image_label":          &b.config.UserImageLabel,
+		"vnet":                      &b.config.VNet,
+		"subnet":                    &b.config.Subnet,
 	}
 
 	for n, ptr := range templates {

--- a/packer/builder/azure/driver_restapi/builder.go
+++ b/packer/builder/azure/driver_restapi/builder.go
@@ -7,6 +7,11 @@ package driver_restapi
 import (
 	"errors"
 	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"time"
+
 	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/constants"
 	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/driver"
 	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/request"
@@ -18,10 +23,6 @@ import (
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/common"
 	"github.com/mitchellh/packer/packer"
-	"log"
-	"os"
-	"regexp"
-	"time"
 )
 
 // Builder implements packer.Builder and builds the actual Azure
@@ -41,6 +42,8 @@ type azure_config struct {
 	Location                string `mapstructure:"location"`
 	InstanceSize            string `mapstructure:"instance_size"`
 	UserImageLabel          string `mapstructure:"user_image_label"`
+	Subnet                  string `mapstructure:"subnet"`
+	VNet                    string `mapstructure:"vnet"`
 	common.PackerConfig     `mapstructure:",squash"`
 	tpl                     *packer.ConfigTemplate
 
@@ -82,6 +85,8 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		"location":                  &b.config.Location,
 		"instance_size":             &b.config.InstanceSize,
 		"user_image_label":          &b.config.UserImageLabel,
+		"subnet":                    &b.config.Subnet,
+		"vnet":                      &b.config.VNet,
 	}
 
 	for n, ptr := range templates {
@@ -158,6 +163,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		targets.A7,
 		targets.A8,
 		targets.A9,
+		targets.D14,
 	}
 
 	log.Println(fmt.Sprintf("%s: %v", "instance_size", b.config.InstanceSize))
@@ -266,6 +272,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	state.Put(constants.DiskExists, 0)
 	state.Put(constants.VmRunning, 0)
 	state.Put(constants.ImageCreated, 0)
+	state.Put(constants.Subnet, 0)
+	state.Put(constants.VNet, 0)
 
 	ui.Say("Validating Azure Options...")
 	err = b.validateAzureOptions(ui, state, reqManager)
@@ -301,6 +309,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				TmpServiceName:          b.config.tmpServiceName,
 				InstanceSize:            b.config.InstanceSize,
 				Username:                b.config.username,
+				Subnet:                  b.config.Subnet,
+				VNet:                    b.config.VNet,
 			},
 
 			&targets.StepPollStatus{
@@ -350,6 +360,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				InstanceSize:            b.config.InstanceSize,
 				Username:                b.config.username,
 				Password:                utils.RandomPassword(),
+				Subnet:                  b.config.Subnet,
+				VNet:                    b.config.VNet,
 			},
 			&targets.StepPollStatus{
 				TmpServiceName: b.config.tmpServiceName,

--- a/packer/builder/azure/driver_restapi/builder.go
+++ b/packer/builder/azure/driver_restapi/builder.go
@@ -102,6 +102,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 	}
 	log.Println(fmt.Sprintf("%s: %v", "subscription_name", b.config.SubscriptionName))
 
+	if b.config.Subnet == "" {
+		errs = packer.MultiErrorAppend(errs, errors.New("subnet: The option can't be missed"))
+	}
+
 	if b.config.PublishSettingsPath == "" {
 		errs = packer.MultiErrorAppend(errs, errors.New("publish_settings_path: The option can't be missed."))
 	}

--- a/packer/builder/azure/driver_restapi/builder.go
+++ b/packer/builder/azure/driver_restapi/builder.go
@@ -102,10 +102,6 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 	}
 	log.Println(fmt.Sprintf("%s: %v", "subscription_name", b.config.SubscriptionName))
 
-	if b.config.Subnet == "" {
-		errs = packer.MultiErrorAppend(errs, errors.New("subnet: The option can't be missed"))
-	}
-
 	if b.config.PublishSettingsPath == "" {
 		errs = packer.MultiErrorAppend(errs, errors.New("publish_settings_path: The option can't be missed."))
 	}

--- a/packer/builder/azure/driver_restapi/builder.go
+++ b/packer/builder/azure/driver_restapi/builder.go
@@ -163,7 +163,6 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		targets.A7,
 		targets.A8,
 		targets.A9,
-		targets.D14,
 	}
 
 	log.Println(fmt.Sprintf("%s: %v", "instance_size", b.config.InstanceSize))

--- a/packer/builder/azure/driver_restapi/builder.go
+++ b/packer/builder/azure/driver_restapi/builder.go
@@ -271,8 +271,6 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	state.Put(constants.DiskExists, 0)
 	state.Put(constants.VmRunning, 0)
 	state.Put(constants.ImageCreated, 0)
-	state.Put(constants.Subnet, 0)
-	state.Put(constants.VNet, 0)
 
 	ui.Say("Validating Azure Options...")
 	err = b.validateAzureOptions(ui, state, reqManager)

--- a/packer/builder/azure/driver_restapi/constants/stateBag.go
+++ b/packer/builder/azure/driver_restapi/constants/stateBag.go
@@ -28,6 +28,8 @@ const (
 	AzureVmAddr        string = "azureVmAddr"
 	HardDiskName       string = "hardDiskName"
 	MediaLink          string = "mediaLink"
+	Subnet             string = "subnet"
+	VNet               string = "vnet"
 
 //	TmpServiceName 		string = "tmpServiceName"
 )

--- a/packer/builder/azure/driver_restapi/request/CreateVirtualMachineDeployment.go
+++ b/packer/builder/azure/driver_restapi/request/CreateVirtualMachineDeployment.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 )
 
-func (m *Manager) CreateVirtualMachineDeploymentLin(isOSImage bool, serviceName, vmName, vmSize, certThumbprint, userName, osImageName, mediaLoc string) *Data {
+func (m *Manager) CreateVirtualMachineDeploymentLin(isOSImage bool, serviceName, vmName, vmSize, certThumbprint, userName, osImageName, mediaLoc string, subnet string, vnet string) *Data {
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/hostedservices/%s/deployments", m.SubscrId, serviceName)
 
@@ -58,6 +58,11 @@ func (m *Manager) CreateVirtualMachineDeploymentLin(isOSImage bool, serviceName,
 	buff.WriteString("<Protocol>tcp</Protocol>")
 	buff.WriteString("</InputEndpoint>")
 	buff.WriteString("</InputEndpoints>")
+	if subnet != "" && vnet != "" {
+		buff.WriteString("<SubnetNames>")
+		buff.WriteString("<SubnetName>" + subnet + "</SubnetName>")
+		buff.WriteString("</SubnetNames>")
+	}
 	buff.WriteString("</ConfigurationSet>")
 	buff.WriteString("</ConfigurationSets>")
 	if !isOSImage {
@@ -72,6 +77,9 @@ func (m *Manager) CreateVirtualMachineDeploymentLin(isOSImage bool, serviceName,
 	buff.WriteString("<ProvisionGuestAgent>true</ProvisionGuestAgent>")
 	buff.WriteString("</Role>")
 	buff.WriteString("</RoleList>")
+	if subnet != "" && vnet != "" {
+		buff.WriteString("<VirtualNetworkName>" + vnet + "</VirtualNetworkName>")
+	}
 	buff.WriteString("</Deployment>")
 
 	data := &Data{

--- a/packer/builder/azure/driver_restapi/request/CreateVirtualMachineDeployment.go
+++ b/packer/builder/azure/driver_restapi/request/CreateVirtualMachineDeployment.go
@@ -92,7 +92,7 @@ func (m *Manager) CreateVirtualMachineDeploymentLin(isOSImage bool, serviceName,
 	return data
 }
 
-func (m *Manager) CreateVirtualMachineDeploymentWin(isOSImage bool, serviceName, vmName, vmSize, userName, userPassword, osImageName, mediaLoc string) *Data {
+func (m *Manager) CreateVirtualMachineDeploymentWin(isOSImage bool, serviceName, vmName, vmSize, userName, userPassword, osImageName, mediaLoc string, subnet string, vnet string) *Data {
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/hostedservices/%s/deployments", m.SubscrId, serviceName)
 
@@ -117,6 +117,11 @@ func (m *Manager) CreateVirtualMachineDeploymentWin(isOSImage bool, serviceName,
 	buff.WriteString("<AdminPassword>" + userPassword + "</AdminPassword>")
 	buff.WriteString("<EnableAutomaticUpdates>true</EnableAutomaticUpdates>")
 	buff.WriteString("<AdminUsername>" + userName + "</AdminUsername>")
+	if subnet != "" && vnet != "" {
+		buff.WriteString("<SubnetNames>")
+		buff.WriteString("<SubnetName>" + subnet + "</SubnetName>")
+		buff.WriteString("</SubnetNames>")
+	}
 	buff.WriteString("</ConfigurationSet>")
 	buff.WriteString("</ConfigurationSets>")
 	if !isOSImage {
@@ -132,6 +137,9 @@ func (m *Manager) CreateVirtualMachineDeploymentWin(isOSImage bool, serviceName,
 	buff.WriteString("<ProvisionGuestAgent>true</ProvisionGuestAgent>")
 	buff.WriteString("</Role>")
 	buff.WriteString("</RoleList>")
+	if subnet != "" && vnet != "" {
+		buff.WriteString("<VirtualNetworkName>" + vnet + "</VirtualNetworkName>")
+	}
 	buff.WriteString("</Deployment>")
 
 	data := &Data{

--- a/packer/builder/azure/driver_restapi/targets/constants.go
+++ b/packer/builder/azure/driver_restapi/targets/constants.go
@@ -16,6 +16,7 @@ const (
 	A7         string = "A7"
 	A8         string = "A8"
 	A9         string = "A9"
+	D14        string = "Standard_D14"
 )
 
 // Target types

--- a/packer/builder/azure/driver_restapi/targets/constants.go
+++ b/packer/builder/azure/driver_restapi/targets/constants.go
@@ -16,7 +16,6 @@ const (
 	A7         string = "A7"
 	A8         string = "A8"
 	A9         string = "A9"
-	D14        string = "Standard_D14"
 )
 
 // Target types

--- a/packer/builder/azure/driver_restapi/targets/lin/step_create_vm.go
+++ b/packer/builder/azure/driver_restapi/targets/lin/step_create_vm.go
@@ -6,6 +6,7 @@ package lin
 
 import (
 	"fmt"
+
 	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/constants"
 	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/request"
 	"github.com/mitchellh/multistep"
@@ -21,6 +22,8 @@ type StepCreateVm struct {
 	TmpServiceName          string
 	InstanceSize            string
 	Username                string
+	Subnet                  string
+	VNet                    string
 }
 
 func (s *StepCreateVm) Run(state multistep.StateBag) multistep.StepAction {
@@ -52,7 +55,7 @@ func (s *StepCreateVm) Run(state multistep.StateBag) multistep.StepAction {
 
 	mediaLoc := fmt.Sprintf("https://%s.blob.core.windows.net/%s/%s.vhd", s.StorageAccount, s.StorageAccountContainer, s.TmpVmName)
 
-	requestData := reqManager.CreateVirtualMachineDeploymentLin(isOSImage, s.TmpServiceName, s.TmpVmName, s.InstanceSize, certThumbprint, s.Username, osImageName, mediaLoc)
+	requestData := reqManager.CreateVirtualMachineDeploymentLin(isOSImage, s.TmpServiceName, s.TmpVmName, s.InstanceSize, certThumbprint, s.Username, osImageName, mediaLoc, s.Subnet, s.VNet)
 	err = reqManager.ExecuteSync(requestData)
 
 	if err != nil {

--- a/packer/builder/azure/driver_restapi/targets/step_create_image.go
+++ b/packer/builder/azure/driver_restapi/targets/step_create_image.go
@@ -6,13 +6,14 @@ package targets
 
 import (
 	"fmt"
+	"log"
+	"strings"
+	"time"
+
 	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/constants"
 	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/request"
 	"github.com/mitchellh/multistep"
 	"github.com/mitchellh/packer/packer"
-	"log"
-	"strings"
-	"time"
 )
 
 type StepCreateImage struct {

--- a/packer/builder/azure/driver_restapi/targets/win/step_create_vm.go
+++ b/packer/builder/azure/driver_restapi/targets/win/step_create_vm.go
@@ -6,6 +6,7 @@ package win
 
 import (
 	"fmt"
+
 	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/constants"
 	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/request"
 	"github.com/mitchellh/multistep"
@@ -22,6 +23,8 @@ type StepCreateVm struct {
 	InstanceSize            string
 	Username                string
 	Password                string
+	Subnet                  string
+	VNet                    string
 }
 
 func (s *StepCreateVm) Run(state multistep.StateBag) multistep.StepAction {

--- a/packer/builder/azure/driver_restapi/targets/win/step_create_vm.go
+++ b/packer/builder/azure/driver_restapi/targets/win/step_create_vm.go
@@ -48,7 +48,7 @@ func (s *StepCreateVm) Run(state multistep.StateBag) multistep.StepAction {
 
 	mediaLoc := fmt.Sprintf("https://%s.blob.core.windows.net/%s/%s.vhd", s.StorageAccount, s.StorageAccountContainer, s.TmpVmName)
 
-	requestData := reqManager.CreateVirtualMachineDeploymentWin(isOSImage, s.TmpServiceName, s.TmpVmName, s.InstanceSize, s.Username, s.Password, osImageName, mediaLoc)
+	requestData := reqManager.CreateVirtualMachineDeploymentWin(isOSImage, s.TmpServiceName, s.TmpVmName, s.InstanceSize, s.Username, s.Password, osImageName, mediaLoc, s.Subnet, s.VNet)
 
 	err = reqManager.ExecuteSync(requestData)
 

--- a/packer/builder/azure/utils/BuildContainerName.go
+++ b/packer/builder/azure/utils/BuildContainerName.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"time"
 )
 
 func BuildContainerName() string {


### PR DESCRIPTION
We require the machines to be spun up from inside a VNet to reach the right resources. This patch allows to add a vnet name and a subnet name that will be used for the temporary VM. 

e.g.
builders : [{
    "type": "azure",
    "vnet": "test-net",
    "subnet": "Subnet0",
    .
    . 
}]

The added fields are optional but if Vnet or Subnet is present, the other has to be as well. The temporary CloudService requires an AffinityGroup of the same name as the VNet though I think it will be created alongside the VNet...  