### PR TITLE
Bugfix for "make temporary container name random"

### DIFF
--- a/packer/builder/azure/utils/BuildContainerName.go
+++ b/packer/builder/azure/utils/BuildContainerName.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"time"
 )
 
 func BuildContainerName() string {


### PR DESCRIPTION
Discovered that the code would not even build due to an import that was left after removing the code that depended on it.