### PR TITLE
replace os/user with github.com/mitchellh/go-homedir to avoid the use of cgo

### DIFF
--- a/packer/builder/azure/driver_restapi/subcriptionManagement.go
+++ b/packer/builder/azure/driver_restapi/subcriptionManagement.go
@@ -11,11 +11,11 @@ import (
 	"encoding/xml"
 	"fmt"
 	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/constants"
+	"github.com/mitchellh/go-homedir"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -114,21 +114,10 @@ func ParsePublishSettings(path string, subscriptionName string) (*SubscriptionIn
 
 	packerSubscriptionStoreDirName := ".packer_azure"
 
-	var usrHome string
-
-	if runtime.GOOS == constants.Windows {
-		usrHome = os.TempDir()
-	} else {
-		log.Println(fmt.Sprintf("getting user home dir..."))
-		// on Windows this operation takes too long (3+ minutes)
-		usr, err := user.Current()
-		if err != nil {
-			return nil, err
-		}
-
-		usrHome = usr.HomeDir
+	usrHome, err := homedir.Dir()
+	if err != nil {
+		return nil, err
 	}
-
 	log.Println(usrHome)
 
 	packerSubscriptionStoreDirPath := filepath.Join(usrHome, packerSubscriptionStoreDirName)


### PR DESCRIPTION
Otherwise when the binary copied to vanilla debian it fails withe following:

$ packer build -var sn=mysubs -var psPath=./my.publishsettings packer-azure.json

==> azure: Preparing builder...
    azure: Getting subscr info...
Build 'azure' errored: ParsePublishSettings error: user: Current not implemented on linux/amd64