### PR TITLE
only use known go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
+  - 1.3
   - 1.4
-  - tip
 
 env:
   - GOTAGS=restapi


### PR DESCRIPTION
'tip' sometimes breaks