### PR TITLE
Add retry logic for Azure service management operations

### DIFF
--- a/packer/builder/azure/driver_restapi/builder.go
+++ b/packer/builder/azure/driver_restapi/builder.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/constants"
-	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/driver"
 	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/request"
 	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/response"
 	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/targets"
@@ -251,24 +250,10 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	var err error
 	ui.Say("Preparing builder...")
 
-	ui.Message("Getting subscr info...")
-	var subscriptionInfo *SubscriptionInfo
-	subscriptionInfo, err = ParsePublishSettings(b.config.PublishSettingsPath, b.config.SubscriptionName)
+	ui.Message("Creating a new request manager...")
+	reqManager, err := request.NewManager(b.config.PublishSettingsPath, b.config.SubscriptionName)
 	if err != nil {
-		return nil, fmt.Errorf("ParsePublishSettings error: %s\n", err.Error())
-	}
-
-	ui.Message("Creating a New Driver...")
-	var driverRest driver.IDriverRest
-	driverRest, err = driver.NewTlsDriver(subscriptionInfo.CertData)
-	if err != nil {
-		return nil, fmt.Errorf("Failed creating rest api driver: %s", err)
-	}
-
-	ui.Message("Creating a New Request Manager...")
-	reqManager := &request.Manager{
-		SubscrId: subscriptionInfo.Id,
-		Driver:   driverRest,
+		return nil, fmt.Errorf("Error creating request manager: %s", err)
 	}
 
 	// Set up the state.

--- a/packer/builder/azure/driver_restapi/request/AddCertificate.go
+++ b/packer/builder/azure/driver_restapi/request/AddCertificate.go
@@ -14,11 +14,6 @@ func (m *Manager) AddCertificate(serviceName, certDataBase64, certFormat, passwo
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/hostedservices/%s/certificates", m.SubscrId, serviceName)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2009-10-01",
-	}
-
 	var buff bytes.Buffer
 	buff.WriteString("<?xml version='1.0' encoding='utf-8'?>")
 	buff.WriteString("<CertificateFile xmlns='http://schemas.microsoft.com/windowsazure'>")
@@ -28,10 +23,9 @@ func (m *Manager) AddCertificate(serviceName, certDataBase64, certFormat, passwo
 	buff.WriteString("</CertificateFile>")
 
 	data := &Data{
-		Verb:    "POST",
-		Uri:     uri,
-		Headers: headers,
-		Body:    &buff,
+		Verb: "POST",
+		Uri:  uri,
+		Body: buff.Bytes(),
 	}
 
 	return data

--- a/packer/builder/azure/driver_restapi/request/AddOSImage.go
+++ b/packer/builder/azure/driver_restapi/request/AddOSImage.go
@@ -13,11 +13,6 @@ import (
 func (m *Manager) AddOSImage(mediaLoc, os, name, label, description, imageFamily, recommendedVMSize, publishedDate string) *Data {
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/images", m.SubscrId)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2014-05-01",
-	}
-
 	language := "english"
 
 	var buff bytes.Buffer
@@ -40,10 +35,9 @@ func (m *Manager) AddOSImage(mediaLoc, os, name, label, description, imageFamily
 	buff.WriteString("</OSImage>")
 
 	data := &Data{
-		Verb:    "POST",
-		Uri:     uri,
-		Headers: headers,
-		Body:    &buff,
+		Verb: "POST",
+		Uri:  uri,
+		Body: buff.Bytes(),
 	}
 
 	return data

--- a/packer/builder/azure/driver_restapi/request/CaptureVMImage.go
+++ b/packer/builder/azure/driver_restapi/request/CaptureVMImage.go
@@ -14,11 +14,6 @@ func (m *Manager) CaptureVMImage(serviceName, vmName, name, label, description, 
 	language := "english"
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/hostedservices/%s/deployments/%s/roleinstances/%s/Operations", m.SubscrId, serviceName, vmName, vmName)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2014-05-01",
-	}
-
 	var buff bytes.Buffer
 	buff.WriteString("<CaptureRoleAsVMImageOperation xmlns='http://schemas.microsoft.com/windowsazure' xmlns:i='http://www.w3.org/2001/XMLSchema-instance'>")
 	buff.WriteString("<OperationType>CaptureRoleAsVMImageOperation</OperationType>")
@@ -32,10 +27,9 @@ func (m *Manager) CaptureVMImage(serviceName, vmName, name, label, description, 
 	buff.WriteString("</CaptureRoleAsVMImageOperation>")
 
 	data := &Data{
-		Verb:    "POST",
-		Uri:     uri,
-		Headers: headers,
-		Body:    &buff,
+		Verb: "POST",
+		Uri:  uri,
+		Body: buff.Bytes(),
 	}
 
 	return data

--- a/packer/builder/azure/driver_restapi/request/CheckStorageAccountNameAvailability.go
+++ b/packer/builder/azure/driver_restapi/request/CheckStorageAccountNameAvailability.go
@@ -10,20 +10,8 @@ import (
 )
 
 func (m *Manager) CheckStorageAccountNameAvailability(storageAccountName string) *Data {
-
-	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/storageservices/operations/isavailable/%s", m.SubscrId, storageAccountName)
-
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2013-03-01",
+	return &Data{
+		Verb: "GET",
+		Uri:  fmt.Sprintf("https://management.core.windows.net/%s/services/storageservices/operations/isavailable/%s", m.SubscrId, storageAccountName),
 	}
-
-	data := &Data{
-		Verb:    "GET",
-		Uri:     uri,
-		Headers: headers,
-		Body:    nil,
-	}
-
-	return data
 }

--- a/packer/builder/azure/driver_restapi/request/CreateCloudService.go
+++ b/packer/builder/azure/driver_restapi/request/CreateCloudService.go
@@ -15,11 +15,6 @@ func (m *Manager) CreateCloudService(serviceName, location string) *Data {
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/hostedservices", m.SubscrId)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2010-10-28",
-	}
-
 	serviceNameLabel := base64.StdEncoding.EncodeToString([]byte(serviceName))
 
 	var buff bytes.Buffer
@@ -32,10 +27,9 @@ func (m *Manager) CreateCloudService(serviceName, location string) *Data {
 	buff.WriteString("</CreateHostedService>")
 
 	data := &Data{
-		Verb:    "POST",
-		Uri:     uri,
-		Headers: headers,
-		Body:    &buff,
+		Verb: "POST",
+		Uri:  uri,
+		Body: buff.Bytes(),
 	}
 
 	return data

--- a/packer/builder/azure/driver_restapi/request/CreateVMImage.go
+++ b/packer/builder/azure/driver_restapi/request/CreateVMImage.go
@@ -13,11 +13,6 @@ import (
 func (m *Manager) CreateVMImage(mediaLoc, os, name, label, description, imageFamily, recommendedVMSize, publishedDate string) *Data {
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/vmimages", m.SubscrId)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2014-05-01",
-	}
-
 	//	language := "english"
 
 	var buff bytes.Buffer
@@ -46,10 +41,9 @@ func (m *Manager) CreateVMImage(mediaLoc, os, name, label, description, imageFam
 	buff.WriteString("</VMImages>")
 
 	data := &Data{
-		Verb:    "POST",
-		Uri:     uri,
-		Headers: headers,
-		Body:    &buff,
+		Verb: "POST",
+		Uri:  uri,
+		Body: buff.Bytes(),
 	}
 
 	return data

--- a/packer/builder/azure/driver_restapi/request/CreateVirtualMachineDeployment.go
+++ b/packer/builder/azure/driver_restapi/request/CreateVirtualMachineDeployment.go
@@ -14,11 +14,6 @@ func (m *Manager) CreateVirtualMachineDeploymentLin(isOSImage bool, serviceName,
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/hostedservices/%s/deployments", m.SubscrId, serviceName)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2014-02-01",
-	}
-
 	var buff bytes.Buffer
 	buff.WriteString("<Deployment xmlns:i='http://www.w3.org/2001/XMLSchema-instance' xmlns='http://schemas.microsoft.com/windowsazure'>")
 	buff.WriteString("<Name>" + vmName + "</Name>")
@@ -75,10 +70,9 @@ func (m *Manager) CreateVirtualMachineDeploymentLin(isOSImage bool, serviceName,
 	buff.WriteString("</Deployment>")
 
 	data := &Data{
-		Verb:    "POST",
-		Uri:     uri,
-		Headers: headers,
-		Body:    &buff,
+		Verb: "POST",
+		Uri:  uri,
+		Body: buff.Bytes(),
 	}
 
 	return data
@@ -87,11 +81,6 @@ func (m *Manager) CreateVirtualMachineDeploymentLin(isOSImage bool, serviceName,
 func (m *Manager) CreateVirtualMachineDeploymentWin(isOSImage bool, serviceName, vmName, vmSize, userName, userPassword, osImageName, mediaLoc string) *Data {
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/hostedservices/%s/deployments", m.SubscrId, serviceName)
-
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2014-05-01",
-	}
 
 	var buff bytes.Buffer
 	buff.WriteString("<Deployment xmlns:i='http://www.w3.org/2001/XMLSchema-instance' xmlns='http://schemas.microsoft.com/windowsazure'>")
@@ -127,10 +116,9 @@ func (m *Manager) CreateVirtualMachineDeploymentWin(isOSImage bool, serviceName,
 	buff.WriteString("</Deployment>")
 
 	data := &Data{
-		Verb:    "POST",
-		Uri:     uri,
-		Headers: headers,
-		Body:    &buff,
+		Verb: "POST",
+		Uri:  uri,
+		Body: buff.Bytes(),
 	}
 
 	return data

--- a/packer/builder/azure/driver_restapi/request/DeleteCloudService.go
+++ b/packer/builder/azure/driver_restapi/request/DeleteCloudService.go
@@ -13,16 +13,9 @@ func (m *Manager) DeleteCloudService(serviceName string) *Data {
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/hostedservices/%s", m.SubscrId, serviceName)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2013-08-01",
-	}
-
 	data := &Data{
-		Verb:    "DELETE",
-		Uri:     uri,
-		Headers: headers,
-		Body:    nil,
+		Verb: "DELETE",
+		Uri:  uri,
 	}
 
 	return data
@@ -32,16 +25,9 @@ func (m *Manager) DeleteCloudServiceAndMedia(serviceName string) *Data {
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/hostedservices/%s?comp=media", m.SubscrId, serviceName)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2013-08-01",
-	}
-
 	data := &Data{
-		Verb:    "DELETE",
-		Uri:     uri,
-		Headers: headers,
-		Body:    nil,
+		Verb: "DELETE",
+		Uri:  uri,
 	}
 
 	return data

--- a/packer/builder/azure/driver_restapi/request/DeleteDeployment.go
+++ b/packer/builder/azure/driver_restapi/request/DeleteDeployment.go
@@ -13,16 +13,9 @@ func (m *Manager) DeleteDeployment(serviceName, vmName string) *Data {
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/hostedservices/%s/deployments/%s", m.SubscrId, serviceName, vmName)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2009-10-01",
-	}
-
 	data := &Data{
-		Verb:    "DELETE",
-		Uri:     uri,
-		Headers: headers,
-		Body:    nil,
+		Verb: "DELETE",
+		Uri:  uri,
 	}
 
 	return data
@@ -33,16 +26,9 @@ func (m *Manager) DeleteDeploymentAndMedia(serviceName, vmName string) *Data {
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/hostedservices/%s/deployments/%s?comp=media", m.SubscrId, serviceName, vmName)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2013-08-01",
-	}
-
 	data := &Data{
-		Verb:    "DELETE",
-		Uri:     uri,
-		Headers: headers,
-		Body:    nil,
+		Verb: "DELETE",
+		Uri:  uri,
 	}
 
 	return data

--- a/packer/builder/azure/driver_restapi/request/DeleteDisk.go
+++ b/packer/builder/azure/driver_restapi/request/DeleteDisk.go
@@ -12,16 +12,9 @@ import (
 func (m *Manager) DeleteDisk(diskName string) *Data {
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/disks/%s", m.SubscrId, diskName)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2012-08-01",
-	}
-
 	data := &Data{
-		Verb:    "DELETE",
-		Uri:     uri,
-		Headers: headers,
-		Body:    nil,
+		Verb: "DELETE",
+		Uri:  uri,
 	}
 
 	return data
@@ -32,16 +25,9 @@ func (m *Manager) DeleteDiskAndMedia(diskName string) *Data {
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/disks/%s?comp=media", m.SubscrId, diskName)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2012-08-01",
-	}
-
 	data := &Data{
-		Verb:    "DELETE",
-		Uri:     uri,
-		Headers: headers,
-		Body:    nil,
+		Verb: "DELETE",
+		Uri:  uri,
 	}
 
 	return data

--- a/packer/builder/azure/driver_restapi/request/DeleteRole.go
+++ b/packer/builder/azure/driver_restapi/request/DeleteRole.go
@@ -13,16 +13,9 @@ func (m *Manager) DeleteRole(serviceName, vmName string) *Data {
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/hostedservices/%s/deployments/%s/roles/%s", m.SubscrId, serviceName, vmName, vmName)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2012-03-01",
-	}
-
 	data := &Data{
-		Verb:    "DELETE",
-		Uri:     uri,
-		Headers: headers,
-		Body:    nil,
+		Verb: "DELETE",
+		Uri:  uri,
 	}
 
 	return data

--- a/packer/builder/azure/driver_restapi/request/GetDeployment.go
+++ b/packer/builder/azure/driver_restapi/request/GetDeployment.go
@@ -13,16 +13,9 @@ func (m *Manager) GetDeployment(serviceName, vmName string) *Data {
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/hostedservices/%s/deployments/%s", m.SubscrId, serviceName, vmName)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2014-06-01",
-	}
-
 	data := &Data{
-		Verb:    "GET",
-		Uri:     uri,
-		Headers: headers,
-		Body:    nil,
+		Verb: "GET",
+		Uri:  uri,
 	}
 
 	return data

--- a/packer/builder/azure/driver_restapi/request/GetOperationStatus.go
+++ b/packer/builder/azure/driver_restapi/request/GetOperationStatus.go
@@ -7,23 +7,58 @@ package request
 
 import (
 	"fmt"
+	"log"
+	"time"
+
+	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/response"
+	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/response/model"
 )
 
-func (m *Manager) GetOperationStatus(requestId string) *Data {
+func (m *Manager) GetOperationStatus(requestId string) (*model.Operation, error) {
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/operations/%s", m.SubscrId, requestId)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2009-10-01",
-	}
-
 	data := &Data{
-		Verb:    "GET",
-		Uri:     uri,
-		Headers: headers,
-		Body:    nil,
+		Verb: "GET",
+		Uri:  uri,
 	}
 
-	return data
+	res, err := m.Execute(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.ParseOperation(res.Body)
+}
+
+var defaultInterval = time.Duration(2 * time.Second)
+
+func (m *Manager) WaitForOperation(requestId string) (operation *model.Operation, err error) {
+	log.Printf("Manager.WaitForOperation (%s)", requestId)
+
+	starttime := time.Now()
+
+	for {
+		nextRequestAt := time.Now().Add(defaultInterval)
+
+		operation, err = m.GetOperationStatus(requestId)
+		if err != nil {
+			return nil, err
+		}
+
+		if operation.Status != "InProgress" {
+			log.Printf("Manager.WaitForOperation (%s) took %v to complete (%v)", requestId, time.Now().Sub(starttime), operation.Status)
+
+			if operation.Status == "Failed" {
+				return operation, operation.Error
+			}
+
+			return operation, nil
+		}
+
+		if wait := nextRequestAt.Sub(time.Now()); wait > 0 {
+			log.Printf("Waiting %v before sending the next request...", wait)
+			time.Sleep(wait)
+		}
+	}
 }

--- a/packer/builder/azure/driver_restapi/request/GetOperationStatus_test.go
+++ b/packer/builder/azure/driver_restapi/request/GetOperationStatus_test.go
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Open Technologies, Inc.
+// All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+// See License.txt in the project root for license information.
+
+package request
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MSOpenTech/packer-azure/mod/pkg/net/http"
+	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/response/model"
+)
+
+func TestWaitForOperation_returns_when_succeeded(t *testing.T) {
+	logs := new(bytes.Buffer)
+	log.SetOutput(logs)
+	defaultInterval = 1 * time.Microsecond
+	responseBody := "<Operation><Status>InProgress</Status></Operation>"
+	m := Manager{httpClient: httpClientStub{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			var rv = http.Response{
+				Body: newStringReader(responseBody),
+			}
+			t.Logf("Exec returning %v", responseBody)
+			return &rv, nil
+		},
+	}}
+	b := newBarrier(1)
+
+	var op *model.Operation
+	var err error
+	go func() {
+		op, err = m.WaitForOperation("bla")
+		t.Logf("WaitForOperation returned with %v,%v", op, err)
+		b.RemoveParticipant()
+		t.Logf("Barrier removed")
+	}()
+
+	if b.WaitFor(0 * time.Second) {
+		t.Fatalf("Expected WaitForOperation to not have returned yet, but it has?")
+	}
+
+	responseBody = "<Operation><Status>Succeeded</Status><ID>test</ID></Operation>"
+
+	if !b.WaitFor(defaultInterval + 5*time.Millisecond) {
+		t.Fatalf("Expected WaitForOperation to have returned, but it hasn't?")
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected err: %T:%v", err, err)
+	}
+	if op == nil || op.ID != "test" {
+		t.Fatalf("unexpected op: %v", op)
+	}
+}
+
+func TestWaitForOperation_returns_when_failed(t *testing.T) {
+	logs := new(bytes.Buffer)
+	log.SetOutput(logs)
+	defaultInterval = 1 * time.Microsecond
+	responseBody := "<Operation><Status>InProgress</Status></Operation>"
+	m := Manager{httpClient: httpClientStub{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			var rv = http.Response{
+				Body: newStringReader(responseBody),
+			}
+			t.Logf("Exec returning %v", responseBody)
+			return &rv, nil
+		},
+	}}
+	b := newBarrier(1)
+
+	var op *model.Operation
+	var err error
+	go func() {
+		op, err = m.WaitForOperation("bla")
+		t.Logf("WaitForOperation returned with %v,%v", op, err)
+		b.RemoveParticipant()
+		t.Logf("Barrier removed")
+	}()
+
+	if b.WaitFor(0 * time.Second) {
+		t.Fatalf("Expected WaitForOperation to not have returned yet, but it has?")
+	}
+
+	responseBody = "<Operation><Status>Failed</Status><ID>test</ID><Error><Code>E1234</Code><Message>some error message</Message></Error></Operation>"
+
+	if !b.WaitFor(defaultInterval + 5*time.Millisecond) {
+		t.Fatalf("Expected WaitForOperation to have returned, but it hasn't?")
+	}
+
+	if err == nil || fmt.Sprintf("%T", err) != "model.AzureError" || err.Error() != "Azure error (E1234): some error message" {
+		t.Fatalf("unexpected err: %T:%v", err, err)
+	}
+	if op == nil || op.ID != "test" {
+		t.Fatalf("unexpected op: %v", op)
+	}
+}
+
+type httpClientStub struct {
+	DoFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (s httpClientStub) Do(req *http.Request) (resp *http.Response, err error) {
+	if s.DoFunc != nil {
+		return s.DoFunc(req)
+	}
+	fmt.Printf("huh?")
+	panic("stub not set up")
+}
+
+type barrier struct {
+	wg sync.WaitGroup
+}
+
+func newBarrier(numParticipants int) *barrier {
+	b := new(barrier)
+	b.wg.Add(numParticipants)
+	return b
+}
+
+func (b *barrier) RemoveParticipant() {
+	b.wg.Done()
+}
+
+func (b *barrier) WaitFor(timeout time.Duration) bool {
+	c := make(chan bool)
+	go func() {
+		b.wg.Wait()
+		c <- true
+	}()
+	t := time.After(timeout)
+	select {
+	case _ = <-c:
+		return true
+	case _ = <-t:
+		return false
+	}
+}
+
+type stringReader struct {
+	reader *strings.Reader
+}
+
+func newStringReader(s string) *stringReader {
+	sr := stringReader{reader: strings.NewReader(s)}
+	return &sr
+}
+
+func (stringReader) Close() error {
+	return nil
+}
+
+func (sr stringReader) Read(p []byte) (n int, err error) {
+	return sr.reader.Read(p)
+}

--- a/packer/builder/azure/driver_restapi/request/GetOsImages.go
+++ b/packer/builder/azure/driver_restapi/request/GetOsImages.go
@@ -13,16 +13,9 @@ func (m *Manager) GetOsImages() *Data {
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/images", m.SubscrId)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2013-03-01",
-	}
-
 	data := &Data{
-		Verb:    "GET",
-		Uri:     uri,
-		Headers: headers,
-		Body:    nil,
+		Verb: "GET",
+		Uri:  uri,
 	}
 
 	return data

--- a/packer/builder/azure/driver_restapi/request/GetStorageAccountKeys.go
+++ b/packer/builder/azure/driver_restapi/request/GetStorageAccountKeys.go
@@ -13,16 +13,9 @@ func (m *Manager) GetStorageAccountKeys(storageAccountName string) *Data {
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/storageservices/%s/keys", m.SubscrId, storageAccountName)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2009-10-01",
-	}
-
 	data := &Data{
-		Verb:    "GET",
-		Uri:     uri,
-		Headers: headers,
-		Body:    nil,
+		Verb: "GET",
+		Uri:  uri,
 	}
 
 	return data

--- a/packer/builder/azure/driver_restapi/request/GetVmImages.go
+++ b/packer/builder/azure/driver_restapi/request/GetVmImages.go
@@ -13,16 +13,9 @@ func (m *Manager) GetVmImages() *Data {
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/vmimages", m.SubscrId)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2014-05-01",
-	}
-
 	data := &Data{
-		Verb:    "GET",
-		Uri:     uri,
-		Headers: headers,
-		Body:    nil,
+		Verb: "GET",
+		Uri:  uri,
 	}
 
 	return data

--- a/packer/builder/azure/driver_restapi/request/ListResourceExtensions.go
+++ b/packer/builder/azure/driver_restapi/request/ListResourceExtensions.go
@@ -13,16 +13,9 @@ func (m *Manager) ListResourceExtensions() *Data {
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/resourceextensions", m.SubscrId)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2013-11-01",
-	}
-
 	data := &Data{
-		Verb:    "GET",
-		Uri:     uri,
-		Headers: headers,
-		Body:    nil,
+		Verb: "GET",
+		Uri:  uri,
 	}
 
 	return data

--- a/packer/builder/azure/driver_restapi/request/ListServiceCertificates.go
+++ b/packer/builder/azure/driver_restapi/request/ListServiceCertificates.go
@@ -13,16 +13,9 @@ func (m *Manager) ListServiceCertificates(serviceName string) *Data {
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/hostedservices/%s/certificates", m.SubscrId, serviceName)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2009-10-01",
-	}
-
 	data := &Data{
-		Verb:    "GET",
-		Uri:     uri,
-		Headers: headers,
-		Body:    nil,
+		Verb: "GET",
+		Uri:  uri,
 	}
 
 	return data

--- a/packer/builder/azure/driver_restapi/request/RetryPolicy.go
+++ b/packer/builder/azure/driver_restapi/request/RetryPolicy.go
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Open Technologies, Inc.
+// All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+// See License.txt in the project root for license information.
+
+package request
+
+import (
+	"log"
+	"strings"
+	"time"
+
+	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/response/model"
+)
+
+func defaultRetryPolicy() retryPolicy {
+	return retryPolicy{
+		exponentialBackoff("Throttling", func(err model.AzureError) bool {
+			return err.Code == "TooManyRequests"
+		}, 5*time.Second, 2*time.Minute, 0),
+		constantBackoff("InternalError", func(err model.AzureError) bool {
+			return err.Code == "InternalError"
+		}, 10*time.Second, 100),
+		constantBackoff("Conflict/InUse", func(err model.AzureError) bool {
+			return (err.Code == "BadRequest" && strings.Contains(err.Message, "is currently in use by")) ||
+				(err.Code == "ConflictError" && strings.Contains(err.Message, "that requires exclusive access"))
+		}, 10*time.Second, 100),
+	}
+}
+
+type retryRule func(model.AzureError) (bool, time.Duration)
+type retryPolicy []retryRule
+type matchRule func(model.AzureError) bool
+
+func (rules retryPolicy) ShouldRetry(err model.AzureError) (shouldRetry bool, backoff time.Duration) {
+	for _, rule := range rules {
+		shouldRetry, backoff = rule(err)
+		if shouldRetry {
+			return
+		}
+	}
+	return false, 0
+}
+
+func constantBackoff(name string, match matchRule, backoff time.Duration, maxRetries int) retryRule {
+	indefinitely := maxRetries == 0
+	retries := 0
+	return func(err model.AzureError) (bool, time.Duration) {
+		if match(err) {
+			if indefinitely || retries < maxRetries {
+				retries++
+				log.Printf("Retry %d for rule '%s' with %v backoff", retries, name, backoff)
+				return true, backoff
+			} else {
+				log.Printf("Retries for rule '%s' exhausted (%d)", name, retries)
+			}
+		}
+		return false, 0
+	}
+}
+
+func exponentialBackoff(name string, match matchRule, initialBackoff time.Duration, maximumBackoff time.Duration, maxRetries int) retryRule {
+	indefinitely := maxRetries == 0
+	retries := 0
+	backoff := initialBackoff
+	return func(err model.AzureError) (bool, time.Duration) {
+		if match(err) {
+			if indefinitely || retries < maxRetries {
+				retries++
+				thisBackoff := backoff
+				backoff *= 2
+				if backoff > maximumBackoff {
+					backoff = maximumBackoff
+				}
+				log.Printf("Retry %d for rule '%s' with %v backoff", retries, name, thisBackoff)
+				return true, thisBackoff
+			} else {
+				log.Printf("Retries for rule '%s' exhausted (%d)", name, retries)
+			}
+		}
+		return false, 0
+	}
+}

--- a/packer/builder/azure/driver_restapi/request/ShutdownRoles.go
+++ b/packer/builder/azure/driver_restapi/request/ShutdownRoles.go
@@ -14,11 +14,6 @@ func (m *Manager) ShutdownRoles(serviceName string, vmName string) *Data {
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/hostedservices/%s/deployments/%s/roles/Operations", m.SubscrId, serviceName, vmName)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2013-06-01",
-	}
-
 	var buff bytes.Buffer
 	buff.WriteString("<ShutdownRolesOperation xmlns='http://schemas.microsoft.com/windowsazure' xmlns:i='http://www.w3.org/2001/XMLSchema-instance'>")
 	buff.WriteString("<OperationType>ShutdownRolesOperation</OperationType>")
@@ -29,10 +24,9 @@ func (m *Manager) ShutdownRoles(serviceName string, vmName string) *Data {
 	buff.WriteString("</ShutdownRolesOperation>")
 
 	data := &Data{
-		Verb:    "POST",
-		Uri:     uri,
-		Headers: headers,
-		Body:    &buff,
+		Verb: "POST",
+		Uri:  uri,
+		Body: buff.Bytes(),
 	}
 
 	return data

--- a/packer/builder/azure/driver_restapi/request/UpdateRole.go
+++ b/packer/builder/azure/driver_restapi/request/UpdateRole.go
@@ -20,11 +20,6 @@ func (m *Manager) UpdateRoleResourceExtensionReference(serviceName, vmName, name
 
 	uri := fmt.Sprintf("https://management.core.windows.net/%s/services/hostedservices/%s/deployments/%s/roles/%s", m.SubscrId, serviceName, vmName, vmName)
 
-	headers := map[string]string{
-		"Content-Type": "application/xml",
-		"x-ms-version": "2014-06-01",
-	}
-
 	var buff bytes.Buffer
 	buff.WriteString("<PersistentVMRole xmlns='http://schemas.microsoft.com/windowsazure' xmlns:i='http://www.w3.org/2001/XMLSchema-instance'>")
 
@@ -56,10 +51,9 @@ func (m *Manager) UpdateRoleResourceExtensionReference(serviceName, vmName, name
 	buff.WriteString("</PersistentVMRole>")
 
 	data := &Data{
-		Verb:    "PUT",
-		Uri:     uri,
-		Headers: headers,
-		Body:    &buff,
+		Verb: "PUT",
+		Uri:  uri,
+		Body: buff.Bytes(),
 	}
 
 	return data

--- a/packer/builder/azure/driver_restapi/request/manager.go
+++ b/packer/builder/azure/driver_restapi/request/manager.go
@@ -6,88 +6,211 @@
 package request
 
 import (
+	"bytes"
+	"encoding/xml"
 	"fmt"
-	"github.com/MSOpenTech/packer-azure/mod/pkg/net/http"
-	restapi "github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/driver"
-	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/response"
-	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/settings"
-	"io"
+	"io/ioutil"
 	"log"
+	"net"
+	neturl "net/url"
+	"os"
+	"strings"
 	"time"
+
+	"github.com/MSOpenTech/packer-azure/mod/pkg/crypto/tls"
+	"github.com/MSOpenTech/packer-azure/mod/pkg/net/http"
+
+	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/response/model"
+	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/settings"
 )
 
+const apiVersion = "2014-06-01" // default API version
+
+var logRequests = os.Getenv("PACKER_AZURE_NOLOG_REQUESTS") == ""
+
 type Data struct {
-	Verb    string
-	Uri     string
-	Headers map[string]string
-	Body    io.Reader
+	Verb string
+	Uri  string
+	Body []byte
+}
+
+type httpClient interface {
+	Do(req *http.Request) (resp *http.Response, err error)
 }
 
 type Manager struct {
-	SubscrId string
-	Driver   restapi.IDriverRest
+	SubscrId   string
+	httpClient httpClient
+}
+
+func NewManager(publishSettingsPath, subscriptionName string) (*Manager, error) {
+	subscriptionInfo, err := ParsePublishSettings(publishSettingsPath, subscriptionName)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to Parse PublishSettings: %v", err)
+	}
+
+	var cert tls.Certificate
+
+	cert, err = tls.X509KeyPair(subscriptionInfo.CertData, subscriptionInfo.CertData)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{Certificates: []tls.Certificate{cert}},
+		},
+	}
+
+	return &Manager{
+		SubscrId:   subscriptionInfo.Id,
+		httpClient: client,
+	}, nil
 }
 
 func (m *Manager) Execute(req *Data) (resp *http.Response, err error) {
-	if settings.LogRequestData {
-		log.Printf("Manager.Execute Request Data:\n %v", req)
-	}
-
-	resp, err = m.Driver.Exec(req.Verb, req.Uri, req.Headers, req.Body)
+	resp, err = m.exec(req.Verb, req.Uri, req.Body, defaultRetryPolicy())
 	return
 }
 
 func (m *Manager) ExecuteSync(req *Data) error {
-	if settings.LogRequestData {
-		log.Printf("Manager.ExecuteSync Request Data:\n %v", req)
-	}
+	retryPolicy := defaultRetryPolicy()
+	for {
+		resp, err := m.exec(req.Verb, req.Uri, req.Body, retryPolicy)
 
-	resp, err := m.Driver.Exec(req.Verb, req.Uri, req.Headers, req.Body)
-
-	if err != nil {
-		return err
-	}
-
-	errorMsg := "Manager.ExecuteSync: %s"
-
-	reqId, ok := resp.Header["X-Ms-Request-Id"]
-	if !ok {
-		return fmt.Errorf(errorMsg, "header key 'X-Ms-Request-Id' wasn't found")
-	}
-
-	count := 60
-	var duration time.Duration = 15
-	sleepTime := time.Second * duration
-
-	for count != 0 {
-		requestData := m.GetOperationStatus(reqId[0])
-		resp, err := m.Execute(requestData)
 		if err != nil {
-			err := fmt.Errorf(errorMsg, err)
 			return err
 		}
 
-		operation, err := response.ParseOperation(resp.Body)
-		log.Println(fmt.Sprintf("operation: %v", operation))
+		errorMsg := fmt.Sprintf("Manager.ExecuteSync (%s %s): %%s", req.Verb, req.Uri)
 
-		if operation.Status == "Succeeded" {
+		reqId, ok := resp.Header["X-Ms-Request-Id"]
+		if !ok {
+			return fmt.Errorf(errorMsg, "header key 'X-Ms-Request-Id' wasn't found")
+		}
+
+		log.Printf("Manager.ExecuteSync (%s %s) start polling for request ID %v", req.Verb, req.Uri, reqId[0])
+
+		if _, err := m.WaitForOperation(reqId[0]); err != nil {
+			if err, isAzureError := err.(model.AzureError); isAzureError {
+				if shouldRetry, backoff := retryPolicy.ShouldRetry(err); shouldRetry {
+					time.Sleep(backoff)
+					continue
+				}
+				log.Printf("Manager.ExecuteSync (%s %s) caught non-retryable error: %v", req.Verb, req.Uri, err)
+			}
+			return err
+		}
+		break
+	}
+	return nil
+}
+
+// Exec executes REST request
+func (d *Manager) exec(verb string, url string, body []byte, retryPolicy retryPolicy) (resp *http.Response, err error) {
+	originalUrl := url // for HTTP 307 redirects
+
+	if body == nil {
+		body = make([]byte, 0)
+	}
+
+	for { // retry loop for azure errors
+		url = originalUrl // reset url
+
+		for { // retry loop for retry-able network errors
+			if logRequests {
+				log.Printf("Exec REQUEST: %s %s\n%s", verb, url, string(body))
+			}
+			req, err := http.NewRequest(verb, url, bytes.NewReader(body))
+			if err != nil {
+				return nil, err
+			}
+			req.Header.Add("Content-Type", "application/xml")
+			req.Header.Add("x-ms-version", apiVersion)
+
+			resp, err = d.httpClient.Do(req)
+
+			if err != nil {
+				switch err := err.(type) {
+				case *neturl.Error:
+					switch err := err.Err.(type) {
+					case *net.OpError:
+						switch {
+						case err.Temporary(),
+							err.Timeout(),
+							strings.Contains(err.Err.Error(), "connection reset by peer"),
+							strings.Contains(err.Err.Error(), "An existing connection was forcibly closed by the remote host"):
+							log.Printf("Encountered retryable error: %+v", err)
+							time.Sleep(500 * time.Millisecond)
+							continue
+						default:
+							log.Printf("unhandled net.OpError (Op=%s, Net=%s, Addr=%+v, Err=%T, %+v)", err.Op, err.Net, err.Addr, err.Err, err.Err)
+						}
+					default:
+						log.Printf("unhandled neturl.Error (Err=%+v, resp=%+v, %T)", err, resp, err)
+					}
+				default:
+					log.Printf("unhandled error from httpClient.Do (Err=%+v, resp=%+v, %T)", err, resp, err)
+				}
+
+				return nil, err
+			}
 			break
 		}
 
-		if operation.Status == "Failed" {
-			return fmt.Errorf(errorMsg, operation.Error.Message)
+		if logRequests {
+			buf := bytes.Buffer{}
+			if _, err := buf.ReadFrom(resp.Body); err != nil {
+				panic(err)
+			}
+			resp.Body.Close()
+			resp.Body = ioutil.NopCloser(&buf)
+			log.Printf("Exec RESPONSE: %s\nHeaders: %+v\n%s", resp.Status, resp.Header, string(buf.Bytes()))
 		}
 
-		// InProgress
-		log.Println(fmt.Sprintf("Waiting for another %v seconds...", uint(duration)))
-		time.Sleep(sleepTime)
-		count--
+		if resp.StatusCode == 307 { // Temporary Redirect
+			locationHeader, ok := resp.Header["Location"]
+			if !ok {
+				log.Printf("%s %s", "Failed to redirect:", "header key 'Location' wasn't found, retrying")
+				continue
+			}
+			url = locationHeader[0]
+			log.Printf("Redirecting: '%s' --> '%s'", originalUrl, url)
+			continue
+		}
+
+		if resp.StatusCode >= 400 && resp.StatusCode <= 505 {
+
+			defer resp.Body.Close()
+
+			var respBody []byte
+			respBody, err = ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+
+			if settings.LogRawResponseError {
+				log.Printf("Exec raw error: %s\nHeaders: %+v\n%s", resp.Status, resp.Header, string(respBody))
+			}
+
+			azureError := model.AzureError{}
+			err = xml.Unmarshal(respBody, &azureError)
+			if err != nil {
+				log.Printf("Exec could not unmarshal error: %v\n%s\nHeaders: %+v\n%s", err, resp.Status, resp.Header, string(respBody))
+				return nil, err
+			}
+
+			if shouldRetry, backoff := retryPolicy.ShouldRetry(azureError); shouldRetry {
+				time.Sleep(backoff)
+				continue
+			}
+
+			return nil, azureError
+		}
+
+		break
 	}
 
-	if count == 0 {
-		err := fmt.Errorf(errorMsg, "timeout")
-		return err
-	}
-
-	return nil
+	return resp, err
 }

--- a/packer/builder/azure/driver_restapi/request/subcriptionManagement.go
+++ b/packer/builder/azure/driver_restapi/request/subcriptionManagement.go
@@ -2,7 +2,7 @@
 // All Rights Reserved.
 // Licensed under the Apache License, Version 2.0.
 // See License.txt in the project root for license information.
-package driver_restapi
+package request
 
 import (
 	"bytes"

--- a/packer/builder/azure/driver_restapi/request_tests/init.go
+++ b/packer/builder/azure/driver_restapi/request_tests/init.go
@@ -6,12 +6,9 @@
 package request_tests
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
-	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi"
-	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/driver"
 	"github.com/MSOpenTech/packer-azure/packer/builder/azure/driver_restapi/request"
 )
 
@@ -22,30 +19,14 @@ func getRequestManager(t *testing.T) (*request.Manager, error) {
 	if psPath == "" {
 		t.Skip("PUBLISHSETTINGS environment variable not set, skipping this test.")
 	}
+
 	if g_reqManager != nil {
 		return g_reqManager, nil
 	}
 
-	var d driver.IDriverRest
-	var err error
-
-	subscriptionInfo, err := driver_restapi.ParsePublishSettings(psPath, "PackerTestSubscription")
-
+	g_reqManager, err := request.NewManager(psPath, "PackerTestSubscription")
 	if err != nil {
-		return nil, fmt.Errorf("ParsePublishSettings error: %s\n", err.Error())
-	}
-
-	fmt.Println("id: " + subscriptionInfo.Id)
-
-	d, err = driver.NewTlsDriver(subscriptionInfo.CertData)
-
-	if err != nil {
-		return nil, fmt.Errorf("NewTlsDriver error: %s\n", err.Error())
-	}
-
-	g_reqManager = &request.Manager{
-		SubscrId: subscriptionInfo.Id,
-		Driver:   d,
+		panic(err)
 	}
 
 	return g_reqManager, err

--- a/packer/builder/azure/driver_restapi/response/model/AzureError.go
+++ b/packer/builder/azure/driver_restapi/response/model/AzureError.go
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Open Technologies, Inc.
+// All Rights Reserved.
+// Licensed under the Apache License, Version 2.0.
+// See License.txt in the project root for license information.
+package model
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+type AzureError struct {
+	XMLName xml.Name `xml:"Error"`
+	Code    string
+	Message string
+}
+
+func (err AzureError) Error() string {
+	return fmt.Sprintf("Azure error (%v): %v", err.Code, err.Message)
+}

--- a/packer/builder/azure/driver_restapi/response/model/Operation.go
+++ b/packer/builder/azure/driver_restapi/response/model/Operation.go
@@ -12,10 +12,5 @@ type Operation struct {
 	ID             string
 	Status         string
 	HttpStatusCode string
-	Error          Error `xml:"Error"`
-}
-
-type Error struct {
-	Code    string
-	Message string
+	Error          AzureError `xml:"Error"`
 }


### PR DESCRIPTION
Removed separate 'driver' concept, collapsed it into the 'manager' object.
Changed from io.Reader to []byte for carrying the request payloads.
Use same api version for all requests.

Fixes #24 
Fixes #25

cc: @ahmetalpbalkan @Snesha @jeffmendoza 