### PR TITLE
Change ip/port format back to %s:%s

### DIFF
--- a/packer/builder/azure/driver_restapi/targets/step_poll_status.go
+++ b/packer/builder/azure/driver_restapi/targets/step_poll_status.go
@@ -132,7 +132,7 @@ func (s *StepPollStatus) Run(state multistep.StateBag) multistep.StepAction {
 
 		vip := endpoints[0].Vip
 		port := endpoints[0].PublicPort
-		endpoint := fmt.Sprintf("%s:%d", vip, port)
+		endpoint := fmt.Sprintf("%s:%s", vip, port)
 
 		ui.Message("VM Endpoint: " + endpoint)
 		state.Put(constants.AzureVmAddr, endpoint)


### PR DESCRIPTION
Fixes #59
Port is read as a string from the XML, so format string also needs to expect a string.

I broke this in 5ff6eda :frowning:... sorry about that

Signed-off-by: Paul Meyer <paul.meyer@microsoft.com>