### PR TITLE
Fix typo in packer-azure output

### DIFF
--- a/packer/builder/azure/driver_restapi/targets/step_create_image.go
+++ b/packer/builder/azure/driver_restapi/targets/step_create_image.go
@@ -29,7 +29,7 @@ func (s *StepCreateImage) Run(state multistep.StateBag) multistep.StepAction {
 
 	errorMsg := "Error Creating Azure Image: %s"
 
-	ui.Say("Creating Azure Image. If Succeed This Will Remove the Temorary VM...")
+	ui.Say("Creating Azure Image. If Successful, This Will Remove the Temporary VM...")
 
 	description := "paker made image"
 	imageFamily := "PackerMade"


### PR DESCRIPTION
Just fixing a typo, trying to make print statement a bit clearer