### PR TITLE
Drop unused IsOSImage variable in stateBag

### DIFF
--- a/packer/builder/azure/constants/stateBag.go
+++ b/packer/builder/azure/constants/stateBag.go
@@ -23,7 +23,6 @@ const (
 	Certificate    string = "certificate"
 	Thumbprint     string = "thumbprint"
 	OSImageName    string = "osImageName"
-	IsOSImage      string = "isOSImage"
 	HardDiskName   string = "hardDiskName"
 	MediaLink      string = "mediaLink"
 	SSHHost        string = "sshHost"

--- a/packer/builder/azure/win/step_set_provision_infrastructure.go
+++ b/packer/builder/azure/win/step_set_provision_infrastructure.go
@@ -70,8 +70,6 @@ func (s *StepSetProvisionInfrastructure) Run(state multistep.StateBag) multistep
 
 	s.flagTempContainerCreated = true
 
-	isOSImage := state.Get(constants.IsOSImage).(bool)
-
 	comm, err := azureVmCustomScriptExtension.New(
 		azureVmCustomScriptExtension.Config{
 			ServiceName:        s.ServiceName,
@@ -80,7 +78,6 @@ func (s *StepSetProvisionInfrastructure) Run(state multistep.StateBag) multistep
 			StorageAccountKey:  keys.PrimaryKey,
 			ContainerName:      s.TempContainerName,
 			Ui:                 ui,
-			IsOSImage:          isOSImage,
 			ManagementClient:   client,
 			ProvisionTimeoutInMinutes: s.ProvisionTimeoutInMinutes,
 		})

--- a/packer/communicator/azureVmCustomScriptExtension/communicator.go
+++ b/packer/communicator/azureVmCustomScriptExtension/communicator.go
@@ -41,7 +41,6 @@ type Config struct {
 	StorageAccountKey         string
 	ContainerName             string
 	Ui                        packer.Ui
-	IsOSImage                 bool
 	ProvisionTimeoutInMinutes uint
 	ManagementClient          management.Client
 


### PR DESCRIPTION
It fails on https://github.com/MSOpenTech/packer-azure/blob/86e4e8392d07bf123c55dfe4e769a9878bfaee24/packer/builder/azure/win/step_set_provision_infrastructure.go#L71 otherwise