### PR TITLE
Long running extensionSettings time out, even if they are still running on the host #52 

### DIFF
--- a/packer/builder/azure/builder.go
+++ b/packer/builder/azure/builder.go
@@ -132,10 +132,11 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				OSType:         b.config.OSType,
 			},
 			&win.StepSetProvisionInfrastructure{
-				VmName:             b.config.tmpVmName,
-				ServiceName:        b.config.tmpServiceName,
-				StorageAccountName: b.config.StorageAccount,
-				TempContainerName:  b.config.tmpContainerName,
+				VmName:                    b.config.tmpVmName,
+				ServiceName:               b.config.tmpServiceName,
+				StorageAccountName:        b.config.StorageAccount,
+				TempContainerName:         b.config.tmpContainerName,
+				ProvisionTimeoutInMinutes: b.config.ProvisionTimeoutInMinutes,
 			},
 			&common.StepProvision{},
 			&StepStopVm{

--- a/packer/builder/azure/config.go
+++ b/packer/builder/azure/config.go
@@ -34,6 +34,8 @@ type Config struct {
 	RemoteSourceImageLink string `mapstructure:"remote_source_image_link"`
 	ResizeOSVhdGB         *int   `mapstructure:"resize_os_vhd_gb"`
 
+	ProvisionTimeoutInMinutes uint `mapstructure:"provision_timeout_in_minutes"`
+
 	VNet   string `mapstructure:"vnet"`
 	Subnet string `mapstructure:"subnet"`
 
@@ -50,6 +52,9 @@ type Config struct {
 
 func newConfig(raws ...interface{}) (*Config, []string, error) {
 	var c Config
+
+	// Default provision timeout
+	c.ProvisionTimeoutInMinutes = 120
 
 	c.ctx = &interpolate.Context{}
 	err := config.Decode(&c, &config.DecodeOpts{

--- a/packer/builder/azure/win/step_set_provision_infrastructure.go
+++ b/packer/builder/azure/win/step_set_provision_infrastructure.go
@@ -19,12 +19,14 @@ import (
 )
 
 type StepSetProvisionInfrastructure struct {
-	VmName                   string
-	ServiceName              string
-	StorageAccountName       string
-	TempContainerName        string
-	storageClient            storage.Client
-	flagTempContainerCreated bool
+	VmName                    string
+	ServiceName               string
+	StorageAccountName        string
+	TempContainerName         string
+	ProvisionTimeoutInMinutes uint
+
+	storageClient             storage.Client
+	flagTempContainerCreated  bool
 }
 
 func (s *StepSetProvisionInfrastructure) Run(state multistep.StateBag) multistep.StepAction {
@@ -80,6 +82,7 @@ func (s *StepSetProvisionInfrastructure) Run(state multistep.StateBag) multistep
 			Ui:                 ui,
 			IsOSImage:          isOSImage,
 			ManagementClient:   client,
+			ProvisionTimeoutInMinutes: s.ProvisionTimeoutInMinutes,
 		})
 
 	if err != nil {


### PR DESCRIPTION
Fix #52 by introducing new config parameter "provision_timeout_in_minutes" with default value of 120 (2 hours). Value of "0" disables timeout entirely.